### PR TITLE
Improve writing navigation and mobile layout

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -25,6 +25,22 @@ body {
   background: rgb(var(--background-start-rgb));
 }
 
+/* Keep long display equations inside the article on narrow screens. */
+.katex-display {
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding-bottom: 0.25rem;
+}
+
+.prose p > .katex {
+  display: inline-block;
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+  vertical-align: middle;
+}
+
 /* Hide scrollbar for Chrome, Safari and Opera */
 ::-webkit-scrollbar {
   display: none;

--- a/app/tweets/page.tsx
+++ b/app/tweets/page.tsx
@@ -13,9 +13,9 @@ export const metadata: Metadata = {
 export default function Tweets() {
     return (
         <div className="flex flex-col min-h-screen bg-black text-white">
-            <Header className="fixed top-0 left-0 right-0 z-10" />
+            <Header className="fixed top-0 left-0 right-0 z-10 border-b border-gray-900 md:border-b-0" />
 
-            <main className="flex-grow pt-24 md:pt-28 px-4 pb-16">
+            <main className="flex-grow px-4 pb-16 pt-32 md:pt-28">
                 <div data-theme="dark" className="mx-auto flex max-w-[550px] flex-col items-center gap-4">
                     {tweets.map((entry) => (
                         <div key={entry.id} className="w-full [&_.react-tweet-theme]:my-0">

--- a/app/writing/page.tsx
+++ b/app/writing/page.tsx
@@ -12,7 +12,7 @@ const articleItems = articles.map(({ content, ...rest }) => rest)
 export default function Writing() {
     return (
         <ContentPage
-            title="MY WRITING"
+            title="WRITING"
             items={articleItems}
             searchPlaceholder="Search articles..."
             baseUrl="/writing"

--- a/components/ArticlePage.tsx
+++ b/components/ArticlePage.tsx
@@ -58,8 +58,8 @@ const TableOfContents: React.FC<{ content: string }> = React.memo(({ content }) 
     }
   
     return (
-      <nav className="toc mb-12 p-6 bg-[#141414] rounded-lg">
-        <h2 className="text-2xl font-bold mb-4 text-white">Table of Contents</h2>
+      <nav className="toc mb-12 rounded-lg bg-[#141414] p-4 sm:p-6">
+        <h2 className="mb-4 text-xl font-bold text-white sm:text-2xl">Table of Contents</h2>
         <ul className="space-y-2">
           {headings.map((heading, index) => {
             const level = heading.match(/^#+/)?.[0].length || 1
@@ -382,11 +382,11 @@ export default function ArticlePage({ title, content, contentType = 'markdown' }
     <div className="flex flex-col min-h-screen bg-black text-white">
       <Header />
       <ProgressBar targetRef={articleRef} />
-      <main className="flex-grow px-4 py-16">
+      <main className="flex-grow px-3 py-10 sm:px-4 sm:py-16">
         <div className="relative max-w-[60rem] mx-auto">
           <div className="absolute inset-0 bg-gradient-to-r from-gray-600 to-[#141414] rounded-lg"></div>
           <div className="relative p-[1px] rounded-lg">
-            <article ref={articleRef} className="p-8 bg-[#141414] rounded-lg">
+            <article ref={articleRef} className="rounded-lg bg-[#141414] p-5 sm:p-8">
               <h1 className="text-3xl md:text-4xl lg:text-5xl font-bold mb-8 text-white leading-tight">
                 {title.split(': ').map((part, index) => (
                   <React.Fragment key={index}>
@@ -428,7 +428,7 @@ export default function ArticlePage({ title, content, contentType = 'markdown' }
       </main>
       <Footer />
       <button
-        className="fixed bottom-8 right-8 p-2 bg-white hover:bg-gray-200 text-black rounded-full shadow-lg transition-all duration-300 opacity-0 hover:opacity-100 focus:opacity-100"
+        className="fixed bottom-4 right-4 rounded-full bg-white p-2 text-black opacity-70 shadow-lg transition-all duration-300 hover:bg-gray-200 hover:opacity-100 focus:opacity-100 md:bottom-8 md:right-8 md:opacity-0"
         onClick={scrollToTop}
         aria-label="Scroll to top"
       >

--- a/components/ContentPage.tsx
+++ b/components/ContentPage.tsx
@@ -36,11 +36,11 @@ export function ContentPage({ title, items, searchPlaceholder, baseUrl, defaultA
 
     return (
         <div className="flex flex-col min-h-screen bg-black text-white">
-            <Header className="fixed top-0 left-0 right-0 z-10" />
+            <Header className="fixed top-0 left-0 right-0 z-10 border-b border-gray-900 md:border-b-0" />
 
-            <div className="flex-grow flex flex-col lg:flex-row pt-16 md:pt-20">
-                <div className="lg:w-1/3 xl:w-1/4 px-6 lg:px-12 py-4 lg:fixed lg:top-20 lg:bottom-0 lg:left-0 lg:overflow-y-auto">
-                    <h1 className="text-5xl lg:text-6xl font-bold mb-8">{title}</h1>
+            <div className="flex-grow flex flex-col pt-28 md:pt-20 lg:flex-row">
+                <div className="px-4 py-6 sm:px-6 lg:fixed lg:top-20 lg:bottom-0 lg:left-0 lg:w-1/3 lg:overflow-y-auto lg:px-12 lg:py-4 xl:w-1/4">
+                    <h1 className="mb-8 text-4xl font-bold sm:text-5xl lg:text-6xl">{title}</h1>
                     <div className="relative w-full max-w-sm">
                         <div className="absolute inset-0 bg-gradient-to-r from-gray-600 to-[#141414] rounded-md"></div>
                         <div className="relative p-[1px] rounded-md">
@@ -63,7 +63,7 @@ export function ContentPage({ title, items, searchPlaceholder, baseUrl, defaultA
                         </div>
                     </div>
                 </div>
-                <main className="lg:w-2/3 xl:w-3/4 lg:ml-[33.333%] xl:ml-[25%] px-6 lg:px-12 py-4">
+                <main className="px-4 py-4 sm:px-6 lg:ml-[33.333%] lg:w-2/3 lg:px-12 xl:ml-[25%] xl:w-3/4">
                     <div className="space-y-4">
                         {filteredItems.map((item, index) => {
                             // Determine the correct href for the item

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -13,7 +13,12 @@ export function Header({ className = '' }: HeaderProps) {
 
     const renderHeaderText = () => {
         if (isHomePage) {
-            return <span className="invisible">GRANT STENGER</span>
+            return (
+                <span aria-hidden="true" className="invisible">
+                    <span className="hidden md:inline">GRANT STENGER</span>
+                    <span className="md:hidden">GS</span>
+                </span>
+            )
         }
         return (
             <Link href="/" className="text-white font-semibold">
@@ -24,25 +29,52 @@ export function Header({ className = '' }: HeaderProps) {
     }
 
     return (
-        <header className={`py-4 md:py-6 bg-black text-white ${className}`}>
-            <nav className="flex justify-between items-center px-4 md:px-6 lg:px-12">
-                {renderHeaderText()}
-                <div className="flex items-center">
-                    <div className="flex space-x-4 md:space-x-6 mr-4 md:mr-6 lg:mr-12">
-                        <Link href="/writing" className="text-gray-400 hover:text-white transition-colors duration-200 underline text-sm md:text-base">WRITING</Link>
-                        <Link href="/books" className="text-gray-400 hover:text-white transition-colors duration-200 underline text-sm md:text-base">BOOKS</Link>
-                        <Link href="/essays" className="text-gray-400 hover:text-white transition-colors duration-200 underline text-sm md:text-base">ESSAYS</Link>
-                        <Link href="/quotes" className="text-gray-400 hover:text-white transition-colors duration-200 underline text-sm md:text-base">QUOTES</Link>
+        <header className={`bg-black py-3 text-white md:py-6 ${className}`}>
+            <nav className="px-4 md:flex md:items-center md:justify-between md:px-6 lg:px-12">
+                <div className="flex items-center justify-between">
+                    {renderHeaderText()}
+                    <div className="-mr-2 flex items-center gap-1 md:hidden">
+                        <SocialLinks />
                     </div>
-                    <div className="flex space-x-2 md:space-x-4">
-                        <SocialLink href="https://twitter.com/GrantStenger" icon={<TwitterIcon />} label="Twitter" />
-                        <SocialLink href="https://github.com/GrantStenger" icon={<GitHubIcon />} label="GitHub" />
-                        <SocialLink href="https://www.instagram.com/grant.stenger/" icon={<InstagramIcon />} label="Instagram" />
-                        <SocialLink href="https://www.linkedin.com/in/grant-stenger/" icon={<LinkedInIcon />} label="LinkedIn" />
+                </div>
+                <div className="mt-1 flex items-center md:mt-0">
+                    <div className="flex w-full items-center justify-between md:mr-6 md:w-auto md:gap-6 lg:mr-12">
+                        <NavLink href="/writing" pathname={pathname}>WRITING</NavLink>
+                        <NavLink href="/books" pathname={pathname}>BOOKS</NavLink>
+                        <NavLink href="/essays" pathname={pathname}>ESSAYS</NavLink>
+                        <NavLink href="/quotes" pathname={pathname}>QUOTES</NavLink>
+                    </div>
+                    <div className="hidden items-center gap-4 md:flex">
+                        <SocialLinks />
                     </div>
                 </div>
             </nav>
         </header>
+    )
+}
+
+function NavLink({ href, pathname, children }: { href: string; pathname: string; children: React.ReactNode }) {
+    const isActive = pathname === href || pathname.startsWith(`${href}/`)
+
+    return (
+        <Link
+            href={href}
+            aria-current={isActive ? 'page' : undefined}
+            className={`${isActive ? 'text-white' : 'text-gray-400'} py-2 text-xs underline transition-colors duration-200 hover:text-white sm:text-sm md:py-0 md:text-base`}
+        >
+            {children}
+        </Link>
+    )
+}
+
+function SocialLinks() {
+    return (
+        <>
+            <SocialLink href="https://twitter.com/GrantStenger" icon={<TwitterIcon />} label="Twitter" />
+            <SocialLink href="https://github.com/GrantStenger" icon={<GitHubIcon />} label="GitHub" />
+            <SocialLink href="https://www.instagram.com/grant.stenger/" icon={<InstagramIcon />} label="Instagram" />
+            <SocialLink href="https://www.linkedin.com/in/grant-stenger/" icon={<LinkedInIcon />} label="LinkedIn" />
+        </>
     )
 }
 
@@ -58,7 +90,7 @@ function SocialLink({ href, icon, label }: SocialLinkProps) {
             href={href}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-[#9CA3AF] hover:text-white transition-colors duration-200"
+            className="p-2 text-[#9CA3AF] transition-colors duration-200 hover:text-white md:p-0"
         >
             {icon}
             <span className="sr-only">{label}</span>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -29,7 +29,7 @@ export function Header({ className = '' }: HeaderProps) {
                 {renderHeaderText()}
                 <div className="flex items-center">
                     <div className="flex space-x-4 md:space-x-6 mr-4 md:mr-6 lg:mr-12">
-                        <Link href="/writing" className="text-gray-400 hover:text-white transition-colors duration-200 underline text-sm md:text-base">MY WRITING</Link>
+                        <Link href="/writing" className="text-gray-400 hover:text-white transition-colors duration-200 underline text-sm md:text-base">WRITING</Link>
                         <Link href="/books" className="text-gray-400 hover:text-white transition-colors duration-200 underline text-sm md:text-base">BOOKS</Link>
                         <Link href="/essays" className="text-gray-400 hover:text-white transition-colors duration-200 underline text-sm md:text-base">ESSAYS</Link>
                         <Link href="/quotes" className="text-gray-400 hover:text-white transition-colors duration-200 underline text-sm md:text-base">QUOTES</Link>

--- a/data/articles.ts
+++ b/data/articles.ts
@@ -1,16 +1,24 @@
 export const articles = [
     {
-      title: "Trillions of Markets",
-      description: "Why a collapse in the cost of making almost anything tradable produces not thousands of markets but trillions.",
-      slug: "trillions-of-markets",
-      author: "Grant Stenger (June 2026)",
-    },
-    {
       title: "Quant Funds and AI Labs Converge",
       description: "An analysis of the convergence between quantitative trading firms and AI research laboratories.",
       slug: "quant-ai-convergence",
       author: "Grant Stenger and Rich Dewey (Jan 2026)",
       link: "https://www.ft.com/content/18313a5f-ae6e-44e9-a26a-4a81cd3190bf"
+    },
+    {
+      title: "Why Local Minima Are Rare in High-Dimensional Landscapes",
+      description: "A note on Hessians, saddles, and Morse critical points: why nondegenerate local minima are exponentially rare among the critical points of high-dimensional random landscapes.",
+      slug: "local-minima",
+      author: "Grant Stenger (May 2025)",
+      pdfUrl: "/local-minima",
+      contentType: "latex",
+    },
+    {
+      title: "Trillions of Markets",
+      description: "Why a collapse in the cost of making almost anything tradable produces not thousands of markets but trillions.",
+      slug: "trillions-of-markets",
+      author: "Grant Stenger (June 2026)",
     },
     {
       title: "SUPA: Solana Uniform-Price Auctions for CPMMs",
@@ -34,14 +42,6 @@ export const articles = [
       slug: "prisoners-dilemma",
       author: "Grant Stenger (Sept 2024)",
       pdfUrl: "/writing/The_Case_for_Cooperation.pdf",
-      contentType: "latex",
-    },
-    {
-      title: "Why Local Minima Are Rare in High-Dimensional Landscapes",
-      description: "A note on Hessians, saddles, and Morse critical points: why nondegenerate local minima are exponentially rare among the critical points of high-dimensional random landscapes.",
-      slug: "local-minima",
-      author: "Grant Stenger (May 2025)",
-      pdfUrl: "/local-minima",
       contentType: "latex",
     },
     {


### PR DESCRIPTION
## Summary
- rename My Writing to Writing and reorder the writing index
- rebuild the mobile header into contained navigation and social rows
- fix fixed-header spacing and mobile article layout
- contain long KaTeX equations on narrow screens

## Validation
- production build passes: yarn build
- changed TypeScript files pass ESLint
- verified at 320px and 390px across home, writing, about, tweets, and article routes
- verified desktop layout at 1280px

## Note
Full-repo lint still reports the existing react-hooks/refs issue in app/writing/trillions-of-markets/AudioPlayer.tsx:30.