### PR TITLE
Update book ranking and writing link behavior

### DIFF
--- a/app/writing/page.tsx
+++ b/app/writing/page.tsx
@@ -17,6 +17,7 @@ export default function Writing() {
             searchPlaceholder="Search articles..."
             baseUrl="/writing"
             defaultAuthor="Grant Stenger"
+            openLinksInNewTab
         />
     )
 }

--- a/components/ContentCard.tsx
+++ b/components/ContentCard.tsx
@@ -6,11 +6,11 @@ interface ContentCardProps {
     author?: string;
     year?: number;
     href?: string;
-    isExternal?: boolean;
+    openInNewTab?: boolean;
     description?: string;
 }
 
-export function ContentCard({ title, author, year, href, isExternal, description }: ContentCardProps) {
+export function ContentCard({ title, author, year, href, openInNewTab, description }: ContentCardProps) {
     const content = (
         <>
             <div className="absolute inset-0 bg-gradient-to-r from-gray-600 to-[#141414] rounded-[9px] opacity-0 group-hover:opacity-100 transition-opacity duration-200"></div>
@@ -49,7 +49,7 @@ export function ContentCard({ title, author, year, href, isExternal, description
             <Link
                 href={href}
                 className="block group relative"
-                {...(isExternal ? {
+                {...(openInNewTab ? {
                     target: "_blank",
                     rel: "noopener noreferrer"
                 } : {})}

--- a/components/ContentPage.tsx
+++ b/components/ContentPage.tsx
@@ -24,9 +24,10 @@ interface ContentPageProps {
     searchPlaceholder: string;
     baseUrl: string;
     defaultAuthor?: string;
+    openLinksInNewTab?: boolean;
 }
 
-export function ContentPage({ title, items, searchPlaceholder, baseUrl, defaultAuthor }: ContentPageProps) {
+export function ContentPage({ title, items, searchPlaceholder, baseUrl, defaultAuthor, openLinksInNewTab = false }: ContentPageProps) {
     const [searchQuery, setSearchQuery] = useState('')
 
     const filteredItems = items.filter(item =>
@@ -87,7 +88,7 @@ export function ContentPage({ title, items, searchPlaceholder, baseUrl, defaultA
                                     author={item.author || defaultAuthor}
                                     year={item.year}
                                     href={href}
-                                    isExternal={!!(item.link || item.pdfUrl)}
+                                    openInNewTab={openLinksInNewTab || !!(item.link || item.pdfUrl)}
                                     description={item.description}
                                 />
                             );

--- a/data/books.json
+++ b/data/books.json
@@ -24,12 +24,6 @@
     "link": "https://www.amazon.com/Walden-Two-B-F-Skinner/dp/0872207781"
   },
   {
-    "title": "The Laws of Trading: A Trader's Guide to Better Decision-Making for Everyone",
-    "author": "Agustin Lebron",
-    "description": "A guide to improving decision-making in trading and beyond, based on principles from game theory and behavioral science.",
-    "link": "https://www.amazon.com/Laws-Trading-Decision-Making-Everyone-Finance/dp/1119574213"
-  },
-  {
     "title": "Candide",
     "author": "Voltaire",
     "description": "A satirical novel that critiques optimism and explores the absurdities of the human condition.",
@@ -100,6 +94,12 @@
     "author": "Marcos Lopez De Prado",
     "description": "A book on applying machine learning techniques to financial markets and trading.",
     "link": "https://www.amazon.com/Advances-Financial-Machine-Learning-Prado/dp/1119482089"
+  },
+  {
+    "title": "The Laws of Trading: A Trader's Guide to Better Decision-Making for Everyone",
+    "author": "Agustin Lebron",
+    "description": "A guide to improving decision-making in trading and beyond, based on principles from game theory and behavioral science.",
+    "link": "https://www.amazon.com/Laws-Trading-Decision-Making-Everyone-Finance/dp/1119574213"
   },
   {
     "title": "Influence: The Psychology of Persuasion",


### PR DESCRIPTION
Moves The Laws of Trading from rank 5 to rank 17 and makes every Writing card open in a new tab. Other content-page link behavior is unchanged.\n\nValidation:\n- npm run build\n- npx eslint components/ContentCard.tsx components/ContentPage.tsx app/writing/page.tsx\n- rendered all 11 Writing cards with target=_blank